### PR TITLE
Change date comparison to days instead of ms

### DIFF
--- a/moment-ferie-fr.js
+++ b/moment-ferie-fr.js
@@ -134,7 +134,7 @@
     moment.fn.getFerie = function () {
       for (var key in listeFerie) {
         if (listeFerie.hasOwnProperty(key)) {
-          if (this.isSame(listeFerie[key].call(this))) {
+          if (this.isSame(listeFerie[key].call(this), 'days')) {
             return key;
           }
         }


### PR DESCRIPTION
Issue when comparing a date which has defined an hour.
```javascript
moment('2017-05-01').isFerie() === moment('2017-05-01 05:10').isFerie()
```
should be true.